### PR TITLE
Use Blender 3.2 release

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+.git
+Dockerfile

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,20 +1,20 @@
 [submodule "release/scripts/addons"]
 	path = release/scripts/addons
-	url = ../blender-addons.git
+	url = https://github.com/blender/blender-addons.git
 	branch = master
 	ignore = all
 [submodule "release/scripts/addons_contrib"]
 	path = release/scripts/addons_contrib
-	url = ../blender-addons-contrib.git
+	url = https://github.com/blender/blender-addons-contrib.git
 	branch = master
 	ignore = all
 [submodule "release/datafiles/locale"]
 	path = release/datafiles/locale
-	url = ../blender-translations.git
+	url = https://github.com/blender/blender-translations.git
 	branch = master
 	ignore = all
 [submodule "source/tools"]
 	path = source/tools
-	url = ../blender-dev-tools.git
+	url = https://github.com/blender/blender-dev-tools.git
 	branch = master
 	ignore = all

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,13 +54,7 @@ COPY --from=0 \
         /etc/ld.so.conf.d/
 
 RUN ln -s python3.7m $(echo /opt/blender/*/python/bin)/python3 && \
-    /opt/blender/*/python/bin/python3 -m ensurepip && \
-    /opt/blender/*/python/bin/pip3 install pillow
-
-RUN --mount=type=ssh \
-    mkdir -p -m 0700 ~/.ssh && \
-    ssh-keyscan github.com >~/.ssh/known_hosts && \
-    /opt/blender/*/python/bin/pip3 install git+ssh://git@github.com/recogni/blender-scripts.git
+    /opt/blender/*/python/bin/python3 -m ensurepip
 
 ENV NVIDIA_VISIBLE_DEVICES all
 ENV NVIDIA_DRIVER_CAPABILITIES all

--- a/Dockerfile
+++ b/Dockerfile
@@ -51,5 +51,8 @@ COPY --from=0 \
     /etc/ld.so.conf.d/osd.conf \
         /etc/ld.so.conf.d/
 
+ENV NVIDIA_VISIBLE_DEVICES all
+ENV NVIDIA_DRIVER_CAPABILITIES all
+
 ENTRYPOINT ["/opt/blender/blender"]
 CMD []

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN echo "deb http://ppa.launchpad.net/apt-fast/stable/ubuntu bionic main" >/etc
 RUN --mount=type=ssh \
     mkdir -p -m 0700 ~/.ssh && \
     ssh-keyscan github.com >~/.ssh/known_hosts && \
-    git clone --branch v7.0.0 git@github.com:recogni/nvidia-optix-sdk /tmp/nvidia-optix-sdk && \
+    git clone --branch v7.2.0 git@github.com:recogni/nvidia-optix-sdk /tmp/nvidia-optix-sdk && \
     mkdir /NVIDIA-OptiX-SDK && \
     sh /tmp/nvidia-optix-sdk/installer/NVIDIA-OptiX-SDK-*.sh --prefix=/NVIDIA-OptiX-SDK --skip-license && \
     rm -rf /tmp/nvidia-optix-sdk

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN cd /blender && \
 RUN --mount=type=ssh \
     mkdir -p -m 0700 ~/.ssh && \
     ssh-keyscan github.com >~/.ssh/known_hosts && \
-    git clone git@github.com:recogni/nvidia-optix-sdk /tmp/nvidia-optix-sdk && \
+    git clone --branch v7.0.0 git@github.com:recogni/nvidia-optix-sdk /tmp/nvidia-optix-sdk && \
     mkdir /NVIDIA-OptiX-SDK && \
     sh /tmp/nvidia-optix-sdk/installer/NVIDIA-OptiX-SDK-*.sh --prefix=/NVIDIA-OptiX-SDK --skip-license && \
     rm -rf /tmp/nvidia-optix-sdk

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,7 @@ COPY --from=0 \
     /blender/build_linux_full/bin /opt/blender
 
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends $(cat /opt/blender/packages.txt) && \
+    apt-get install -y --no-install-recommends git openssh-client $(cat /opt/blender/packages.txt) && \
     rm -rf /var/lib/apt/lists/*
 
 COPY --from=0 \
@@ -55,6 +55,11 @@ COPY --from=0 \
 
 RUN /opt/blender/*/python/bin/python3.7m -m ensurepip && \
     /opt/blender/*/python/bin/pip3 install pillow
+
+RUN --mount=type=ssh \
+    mkdir -p -m 0700 ~/.ssh && \
+    ssh-keyscan github.com >~/.ssh/known_hosts && \
+    /opt/blender/*/python/bin/pip3 install git+ssh://git@github.com/recogni/fuzz-py.git
 
 ENV NVIDIA_VISIBLE_DEVICES all
 ENV NVIDIA_DRIVER_CAPABILITIES all

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,45 @@
+FROM nvidia/cuda:10.1-devel-ubuntu18.04
+
+RUN echo "deb http://ppa.launchpad.net/apt-fast/stable/ubuntu bionic main" >/etc/apt/sources.list.d/apt-fast.list && \
+    apt-key adv --keyserver keyserver.ubuntu.com --recv-keys A2166B8DE8BDC3367D1901C11EE2FF37CA8DA16B && \
+    apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y apt-fast && \
+    apt-fast install -y sudo git build-essential libopenexr-dev libopencolorio-dev opencolorio-tools
+
+COPY / /blender/workspace
+
+RUN cd /blender && \
+    sed 's/apt-get[[:space:]][[:space:]]*install/apt-fast install/' <workspace/build_files/build_environment/install_deps.sh >install_deps.sh && \
+    chmod +x install_deps.sh && \
+    TERM=dumb ./install_deps.sh --no-confirm --skip-ocio --skip-openexr --skip-osl --skip-alembic --build-numpy
+
+RUN cd /blender && \
+    grep '^[[:space:]]*make' BUILD_NOTES.txt | sed 's/"[[:space:]]*$/ -D WITH_CYCLES_CUDA_BINARIES=ON -D WITH_OPENCOLORIO=ON" full/' | tee build.sh && \
+    chmod +x build.sh && \
+    cd workspace && \
+    ../build.sh
+
+RUN dpkg -S $(ldd /blender/build_linux_full/bin/blender | awk '{print $3}') 2>/dev/null | \
+        awk '{print $1}' | sed 's/:.*$//' | sort -u >/blender/build_linux_full/bin/packages.txt
+
+FROM nvidia/cuda:10.1-devel-ubuntu18.04
+
+COPY --from=0 \
+    /blender/build_linux_full/bin /opt/blender
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends $(cat /opt/blender/packages.txt) && \
+    rm -rf /var/lib/apt/lists/*
+
+COPY --from=0 \
+    /opt /opt
+
+COPY --from=0 \
+    /etc/ld.so.conf.d/blosc.conf \
+    /etc/ld.so.conf.d/oiio.conf \
+    /etc/ld.so.conf.d/openvdb.conf \
+    /etc/ld.so.conf.d/osd.conf \
+        /etc/ld.so.conf.d/
+
+ENTRYPOINT ["/opt/blender/blender"]
+CMD []

--- a/Dockerfile
+++ b/Dockerfile
@@ -60,7 +60,7 @@ RUN ln -s python3.7m $(echo /opt/blender/*/python/bin)/python3 && \
 RUN --mount=type=ssh \
     mkdir -p -m 0700 ~/.ssh && \
     ssh-keyscan github.com >~/.ssh/known_hosts && \
-    /opt/blender/*/python/bin/pip3 install git+ssh://git@github.com/recogni/fuzz-py.git
+    /opt/blender/*/python/bin/pip3 install git+ssh://git@github.com/recogni/blender-scripts.git
 
 ENV NVIDIA_VISIBLE_DEVICES all
 ENV NVIDIA_DRIVER_CAPABILITIES all

--- a/Dockerfile
+++ b/Dockerfile
@@ -53,6 +53,9 @@ COPY --from=0 \
     /etc/ld.so.conf.d/osd.conf \
         /etc/ld.so.conf.d/
 
+RUN /opt/blender/*/python/bin/python3.7m -m ensurepip && \
+    /opt/blender/*/python/bin/pip3 install pillow
+
 ENV NVIDIA_VISIBLE_DEVICES all
 ENV NVIDIA_DRIVER_CAPABILITIES all
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
 # syntax = docker/dockerfile:experimental
 
-FROM nvidia/cuda:10.1-devel-ubuntu18.04
+FROM nvidia/cuda:11.1-devel-ubuntu20.04
 
 RUN echo "deb http://ppa.launchpad.net/apt-fast/stable/ubuntu bionic main" >/etc/apt/sources.list.d/apt-fast.list && \
     apt-key adv --keyserver keyserver.ubuntu.com --recv-keys A2166B8DE8BDC3367D1901C11EE2FF37CA8DA16B && \
     apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y apt-fast && \
-    apt-fast install -y sudo git build-essential libopenexr-dev libopencolorio-dev opencolorio-tools
+    apt-fast install -y sudo git build-essential libopenexr-dev libopencolorio-dev opencolorio-tools libtbb-dev libembree-dev
 
 RUN --mount=type=ssh \
     mkdir -p -m 0700 ~/.ssh && \
@@ -34,7 +34,7 @@ RUN cd /blender && \
 RUN dpkg -S $(ldd /blender/build_linux_full/bin/blender | awk '{print $3}') 2>/dev/null | \
         awk '{print $1}' | sed 's/:.*$//' | sort -u >/blender/build_linux_full/bin/packages.txt
 
-FROM nvidia/cuda:10.1-devel-ubuntu18.04
+FROM nvidia/cuda:11.1-devel-ubuntu20.04
 
 COPY --from=0 \
     /blender/build_linux_full/bin /opt/blender

--- a/Dockerfile
+++ b/Dockerfile
@@ -53,7 +53,8 @@ COPY --from=0 \
     /etc/ld.so.conf.d/osd.conf \
         /etc/ld.so.conf.d/
 
-RUN /opt/blender/*/python/bin/python3.7m -m ensurepip && \
+RUN ln -s python3.7m $(echo /opt/blender/*/python/bin)/python3 && \
+    /opt/blender/*/python/bin/python3 -m ensurepip && \
     /opt/blender/*/python/bin/pip3 install pillow
 
 RUN --mount=type=ssh \

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN echo "deb http://ppa.launchpad.net/apt-fast/stable/ubuntu bionic main" >/etc
     apt-key adv --keyserver keyserver.ubuntu.com --recv-keys A2166B8DE8BDC3367D1901C11EE2FF37CA8DA16B && \
     apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y apt-fast && \
-    apt-fast install -y sudo git build-essential libopenexr-dev libopencolorio-dev opencolorio-tools libtbb-dev libembree-dev \
+    apt-fast install -y sudo git build-essential libopenexr-dev libtbb-dev libembree-dev \
         'libboost-(filesystem|iostreams|locale|regex|system|thread|wave|program-options)1.71-dev'
 
 RUN --mount=type=ssh \
@@ -22,7 +22,7 @@ COPY /build_files/build_environment/install_deps.sh /blender/workspace/build_fil
 RUN cd /blender && \
     sed 's/apt-get[[:space:]][[:space:]]*install/apt-fast install/' <workspace/build_files/build_environment/install_deps.sh >install_deps.sh && \
     chmod +x install_deps.sh && \
-    TERM=dumb ./install_deps.sh --no-confirm --skip-ocio --skip-openexr --skip-osl --skip-alembic --skip-boost --build-numpy --build-python
+    TERM=dumb ./install_deps.sh --no-confirm --skip-openexr --skip-osl --skip-alembic --skip-boost --build-numpy --build-python
 
 COPY / /blender/workspace
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,8 @@ RUN echo "deb http://ppa.launchpad.net/apt-fast/stable/ubuntu bionic main" >/etc
     apt-key adv --keyserver keyserver.ubuntu.com --recv-keys A2166B8DE8BDC3367D1901C11EE2FF37CA8DA16B && \
     apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y apt-fast && \
-    apt-fast install -y sudo git build-essential libopenexr-dev libopencolorio-dev opencolorio-tools libtbb-dev libembree-dev
+    apt-fast install -y sudo git build-essential libopenexr-dev libopencolorio-dev opencolorio-tools libtbb-dev libembree-dev \
+        'libboost-(filesystem|iostreams|locale|regex|system|thread|wave|program-options)1.71-dev'
 
 RUN --mount=type=ssh \
     mkdir -p -m 0700 ~/.ssh && \
@@ -21,7 +22,7 @@ COPY /build_files/build_environment/install_deps.sh /blender/workspace/build_fil
 RUN cd /blender && \
     sed 's/apt-get[[:space:]][[:space:]]*install/apt-fast install/' <workspace/build_files/build_environment/install_deps.sh >install_deps.sh && \
     chmod +x install_deps.sh && \
-    TERM=dumb ./install_deps.sh --no-confirm --skip-ocio --skip-openexr --skip-osl --skip-alembic --build-numpy
+    TERM=dumb ./install_deps.sh --no-confirm --skip-ocio --skip-openexr --skip-osl --skip-alembic --skip-boost --build-numpy --build-python
 
 COPY / /blender/workspace
 
@@ -51,7 +52,7 @@ COPY --from=0 \
         /etc/ld.so.conf.d/
 
 RUN ldconfig && \
-    ln -s python3.7m $(echo /opt/blender/*/python/bin)/python3 && \
+    ln -s python3.9 $(echo /opt/blender/*/python/bin)/python3 && \
     /opt/blender/*/python/bin/python3 -m ensurepip
 
 ENV NVIDIA_VISIBLE_DEVICES all

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,31 +1,68 @@
+scmVars = [:]
+activeStageName = ""
+dockerImages = []
+
 pipeline {
     agent any
 
-    environment {
-        BLENDER_ROOT = '/var/lib/jenkins/blender'
+    options {
+        skipDefaultCheckout()
     }
 
-    options {
-        buildDiscarder(logRotator(numToKeepStr: '3', artifactNumToKeepStr: '3'))
+    environment {
+        GCP_PROJECT_ID = sh(script: "gcloud config get-value project", returnStdout: true).trim()
+        DOCKER_REPOSITORY = "us.gcr.io"
+        DOCKER_BUILDKIT = "1"
+        SLACK_CHANNEL = "dev-id"
     }
 
     stages {
-
-        stage('Setup') {
+        stage("Checkout") {
             steps {
-                sh '/opt/bitnami/git/bin/git submodule update --init --recursive'
-                sh 'make update'
+                script {
+                    activeStageName = env.STAGE_NAME
+
+                    scmVars = checkout([$class: 'GitSCM',
+                                        branches: scm.branches,
+                                        doGenerateSubmoduleConfigurations: false,
+                                        extensions: scm.extensions + [[$class: 'SubmoduleOption', parentCredentials: true]],
+                                        userRemoteConfigs: scm.userRemoteConfigs])
+
+                    scmVars.GIT_URL = scmVars.GIT_URL.replaceFirst(/\.git$/, "")
+                    scmVars.GIT_REPOSITORY = scmVars.GIT_URL.replaceFirst(/^[a-z]+:\/\/[^\/]*\//, "")
+                    scmVars.GIT_AUTHOR = sh(script: "${GIT_EXEC_PATH}/git log -1 --pretty=%an ${scmVars.GIT_COMMIT}", returnStdout: true).trim()
+                    scmVars.GIT_MESSAGE = sh(script: "${GIT_EXEC_PATH}/git log -1 --pretty=%s ${scmVars.GIT_COMMIT}", returnStdout: true).trim()
+
+                    scmVars.each { k, v ->
+                         env."${k}" = "${v}"
+                    }
+                }
             }
         }
 
-        stage('Build') {
+        stage("Build") {
             steps {
-                sh 'cd .. && ./blender/build_files/build_environment/install_deps.sh'
-                sh 'make full'
-            }
-            post {
-                always {
-                    archiveArtifacts '../build_linux/bin/blender'
+                sh("gcloud auth configure-docker --quiet")
+
+                script {
+                    activeStageName = env.STAGE_NAME
+
+                    docker.withRegistry("https://${env.DOCKER_REPOSITORY}") {
+                        dockerImage = docker.build("${env.DOCKER_REPOSITORY}/${env.GCP_PROJECT_ID}/blender:${env.BUILD_ID}",
+                                                   " -f Dockerfile" +
+                                                   " --pull" +
+                                                   " .")
+                        dockerImages << dockerImage
+
+			dockerImage.push("${env.BUILD_ID}-${scmVars.GIT_COMMIT.substring(0,8)}")
+
+                        if (scmVars.GIT_BRANCH == "recogni") {
+                            dockerImage.push("latest")
+                        }
+                        else {
+                            dockerImage.push("${scmVars.GIT_BRANCH.replaceAll(/[^0-9A-Za-z_]/, "-")}-latest")
+                        }
+                    }
                 }
             }
         }
@@ -33,7 +70,58 @@ pipeline {
 
     post {
         always {
-            deleteDir()
+            script {
+                dockerImages.each() { dockerImage ->
+                    sh("docker image rm -f \$(docker image ls --format '{{.ID}}' ${dockerImage.id})")
+                }
+
+                sh("""#!/bin/bash -xe
+                   docker image prune -f
+                   docker container prune -f --filter 'until=24h'
+                   """)
+            }
+        }
+
+        success {
+            sendSlackMessage("Success", "good")
+        }
+
+        failure {
+            sendSlackMessage("Failure (${activeStageName})", "danger")
         }
     }
+}
+
+void sendSlackMessage(String result = "Success", String color = "good") {
+    def author = scmVars.GIT_AUTHOR.split().first().toLowerCase()
+    def message = "${result}: ${author.capitalize()}'s build <${currentBuild.absoluteUrl}|${currentBuild.displayName}> in <${scmVars.GIT_URL}|${scmVars.GIT_REPOSITORY}> (<${scmVars.GIT_URL}/commit/${scmVars.GIT_COMMIT}|${scmVars.GIT_COMMIT.substring(0,8)}> on <${scmVars.GIT_URL}/tree/${scmVars.GIT_BRANCH}|${scmVars.GIT_BRANCH}>)\n• ${scmVars.GIT_MESSAGE}"
+
+    dockerImages.collect() { dockerImage ->
+        dockerImage.imageName().split(":").first()
+    }.toSet().each() { imageName ->
+        message += "\nPushed: <https://console.cloud.google.com/gcr/images/${env.GCP_PROJECT_ID}/${env.DOCKER_REPOSITORY.replaceFirst(/\.gcr\.io$/, "")}/${imageName.split("/")[-1]}|${imageName}:*>"
+    }
+
+    if (scmVars.GIT_BRANCH =~ /\b(wip)\b/) {
+        channel = "@" + getMatchingSlackUsername(author)
+    }
+    else {
+        channel = env.SLACK_CHANNEL
+    }
+
+    slackSend(channel: channel,
+              color: color,
+              message: message)
+}
+
+import static org.apache.commons.lang3.StringUtils.getLevenshteinDistance
+
+@NonCPS
+String getMatchingSlackUsername(String author) {
+    userName =
+        ["berend", "eugene", "gilles", "martin", "shaba"].sort { a, b ->
+            getLevenshteinDistance(author, a) <=> getLevenshteinDistance(author, b)
+        }.first()
+
+    return userName
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,7 +13,7 @@ pipeline {
         GCP_PROJECT_ID = sh(script: "gcloud config get-value project", returnStdout: true).trim()
         DOCKER_REPOSITORY = "us.gcr.io"
         DOCKER_BUILDKIT = "1"
-        SLACK_CHANNEL = "dev-synthetic"
+        SLACK_CHANNEL = "dev-synthetic-bots"
     }
 
     stages {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,7 +13,7 @@ pipeline {
 
         stage('Setup') {
             steps {
-                sh 'git submodule update --init --recursive'
+                sh '/opt/bitnami/git/bin/git submodule update --init --recursive'
                 sh 'make update'
             }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,39 @@
+pipeline {
+    agent any
+
+    environment {
+        BLENDER_ROOT = '/var/lib/jenkins/blender'
+    }
+
+    options {
+        buildDiscarder(logRotator(numToKeepStr: '3', artifactNumToKeepStr: '3'))
+    }
+
+    stages {
+
+        stage('Setup') {
+            steps {
+                sh 'git submodule update --init --recursive'
+                sh 'make update'
+            }
+        }
+
+        stage('Build') {
+            steps {
+                sh 'cd .. && ./blender/build_files/build_environment/install_deps.sh'
+                sh 'make full'
+            }
+            post {
+                always {
+                    archiveArtifacts '../build_linux/bin/blender'
+                }
+            }
+        }
+    }
+
+    post {
+        always {
+            deleteDir()
+        }
+    }
+}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,7 +13,7 @@ pipeline {
         GCP_PROJECT_ID = sh(script: "gcloud config get-value project", returnStdout: true).trim()
         DOCKER_REPOSITORY = "us.gcr.io"
         DOCKER_BUILDKIT = "1"
-        SLACK_CHANNEL = "dev-id"
+        SLACK_CHANNEL = "dev-synthetic"
     }
 
     stages {

--- a/release/scripts/modules/pycompositor.py
+++ b/release/scripts/modules/pycompositor.py
@@ -1,0 +1,40 @@
+import numpy as np
+from PIL import Image, ImageOps
+
+
+def mix_arrays(a, b, factor):
+    """Basic linear interpolation, factor from 0.0 to 1.0"""
+    return a + max(min(factor, 1.0), 0.0) * (b - a)
+
+
+def get_array_rgb(rgba):
+    """Return RGB values of an RGBA 3D-array."""
+    return rgba[...,0:3]
+
+
+def get_array_alpha(rgba):
+    """Return alpha values of an RGBA 3D-array."""
+    return rgba[...,3]
+
+
+def array_to_pil(rgba):
+    """Convert a 3D floating point numpy array into a PIL image. Returns the image and
+        a meta object that should be passed to pil_to_array() once the image is
+        converted back into an array."""
+    maxRgb = max(get_array_rgb(rgba).max(), 1.0)
+    maxAlpha = max(get_array_alpha(rgba).max(), 1.0)
+
+    #Normalize values to 8-bit range (0-255) that Pillow can handle
+    norm = rgba / maxRgb * 255.0 #RGB values
+    norm[...,3] = rgba[...,3] / maxAlpha * 255.0 #Alpha value
+    im = ImageOps.flip(Image.fromarray(np.uint8(norm), "RGBA"))
+    return im, (maxRgb, maxAlpha)
+
+
+def pil_to_array(im, meta):
+    """Convert a PIL image into a 3D floating point numpy array."""
+    #Restore values from 0-255 range to original floating point values
+    rgba = np.array(ImageOps.flip(im)) / 255.0
+    rgba[...,0:3] *= meta[0]
+    rgba[...,3] *= meta[1]
+    return rgba

--- a/release/scripts/startup/nodeitems_builtins.py
+++ b/release/scripts/startup/nodeitems_builtins.py
@@ -366,6 +366,7 @@ compositor_node_categories = [
         NodeItem("CompositorNodeInpaint"),
         NodeItem("CompositorNodeDBlur"),
         NodeItem("CompositorNodePixelate"),
+        NodeItem("CompositorNodePython"),
         NodeItem("CompositorNodeSunBeams"),
         NodeItem("CompositorNodeDenoise"),
     ]),

--- a/release/scripts/startup/nodeitems_builtins.py
+++ b/release/scripts/startup/nodeitems_builtins.py
@@ -366,9 +366,10 @@ compositor_node_categories = [
         NodeItem("CompositorNodeInpaint"),
         NodeItem("CompositorNodeDBlur"),
         NodeItem("CompositorNodePixelate"),
-        NodeItem("CompositorNodePython"),
         NodeItem("CompositorNodeSunBeams"),
         NodeItem("CompositorNodeDenoise"),
+        NodeItem("CompositorNodePython"),
+        NodeItem("CompositorNodeRecogniObjectID"),
     ]),
     CompositorNodeCategory("CMP_OP_VECTOR", "Vector", items=[
         NodeItem("CompositorNodeNormal"),

--- a/source/blender/blenkernel/BKE_node.h
+++ b/source/blender/blenkernel/BKE_node.h
@@ -1211,6 +1211,11 @@ void ntreeGPUMaterialNodes(struct bNodeTree *localtree,
 #define CMP_NODE_EXPOSURE 325
 #define CMP_NODE_CRYPTOMATTE 326
 
+/* 
+ *  Recogni: Define custom python recogni node.
+ */
+#define CMP_NODE_PYTHON 400
+
 /* channel toggles */
 #define CMP_CHAN_RGB 1
 #define CMP_CHAN_A 2

--- a/source/blender/blenkernel/BKE_node.h
+++ b/source/blender/blenkernel/BKE_node.h
@@ -1214,7 +1214,8 @@ void ntreeGPUMaterialNodes(struct bNodeTree *localtree,
 /* 
  *  Recogni: Define custom python recogni node.
  */
-#define CMP_NODE_PYTHON 400
+#define CMP_NODE_PYTHON 350
+#define CMP_NODE_RECOGNI_OBJECT_ID (CMP_NODE_PYTHON + 1)
 
 /* channel toggles */
 #define CMP_CHAN_RGB 1

--- a/source/blender/blenkernel/intern/node.cc
+++ b/source/blender/blenkernel/intern/node.cc
@@ -4693,6 +4693,11 @@ static void registerCompositNodes()
   register_node_type_cmp_defocus();
   register_node_type_cmp_sunbeams();
   register_node_type_cmp_denoise();
+  
+  /* 
+   *  Recogni: Register custom python node.
+   */
+  register_node_type_cmp_python();
 
   register_node_type_cmp_valtorgb();
   register_node_type_cmp_rgbtobw();

--- a/source/blender/blenkernel/intern/node.cc
+++ b/source/blender/blenkernel/intern/node.cc
@@ -4698,6 +4698,7 @@ static void registerCompositNodes()
    *  Recogni: Register custom python node.
    */
   register_node_type_cmp_python();
+  register_node_type_cmp_recogni_object_id();
 
   register_node_type_cmp_valtorgb();
   register_node_type_cmp_rgbtobw();

--- a/source/blender/compositor/CMakeLists.txt
+++ b/source/blender/compositor/CMakeLists.txt
@@ -39,10 +39,12 @@ set(INC
   ../../../extern/clew/include
   ../../../intern/atomic
   ../../../intern/guardedalloc
+  ${PYTHON_NUMPY_INCLUDE_DIRS}
 )
 
 set(INC_SYS
-
+  ${PYTHON_INCLUDE_DIRS}
+  ${PYTHON_NUMPY_INCLUDE_DIRS}
 )
 
 set(SRC
@@ -280,6 +282,13 @@ set(SRC
   nodes/COM_VectorBlurNode.h
   operations/COM_VectorBlurOperation.cc
   operations/COM_VectorBlurOperation.h
+
+  # Recogni : Custom python node
+  nodes/COM_PythonNode.cpp
+  nodes/COM_PythonNode.h
+  operations/COM_PythonOperation.cpp
+  operations/COM_PythonOperation.h
+
   nodes/COM_BlurNode.cc
   nodes/COM_BlurNode.h
   nodes/COM_BokehBlurNode.cc

--- a/source/blender/compositor/CMakeLists.txt
+++ b/source/blender/compositor/CMakeLists.txt
@@ -289,6 +289,11 @@ set(SRC
   operations/COM_PythonOperation.cpp
   operations/COM_PythonOperation.h
 
+  nodes/COM_RecogniObjectIDNode.cpp
+  nodes/COM_RecogniObjectIDNode.h
+  operations/COM_RecogniObjectIDOperation.cpp
+  operations/COM_RecogniObjectIDOperation.h
+
   nodes/COM_BlurNode.cc
   nodes/COM_BlurNode.h
   nodes/COM_BokehBlurNode.cc

--- a/source/blender/compositor/intern/COM_Converter.cc
+++ b/source/blender/compositor/intern/COM_Converter.cc
@@ -117,6 +117,7 @@
 
 /* Recogni : Custom python node */
 #include "COM_PythonNode.h"
+#include "COM_RecogniObjectIDNode.h"
 
 bool COM_bnode_is_fast_node(const bNode &b_node)
 {
@@ -406,10 +407,6 @@ Node *COM_convert_bnode(bNode *b_node)
     case CMP_NODE_CORNERPIN:
       node = new CornerPinNode(b_node);
       break;
-    /* Recogni : Custom python node */
-    case CMP_NODE_PYTHON:
-      node = new PythonNode(b_node);
-      break;
     case CMP_NODE_SUNBEAMS:
       node = new SunBeamsNode(b_node);
       break;
@@ -424,6 +421,13 @@ Node *COM_convert_bnode(bNode *b_node)
       break;
     case CMP_NODE_EXPOSURE:
       node = new ExposureNode(b_node);
+      break;
+    /* Recogni : Custom python node */
+    case CMP_NODE_PYTHON:
+      node = new PythonNode(b_node);
+      break;
+    case CMP_NODE_RECOGNI_OBJECT_ID:
+      node = new RecogniObjectIDNode(b_node);
       break;
   }
   return node;

--- a/source/blender/compositor/intern/COM_Converter.cc
+++ b/source/blender/compositor/intern/COM_Converter.cc
@@ -115,6 +115,9 @@
 #include "COM_ViewerNode.h"
 #include "COM_ZCombineNode.h"
 
+/* Recogni : Custom python node */
+#include "COM_PythonNode.h"
+
 bool COM_bnode_is_fast_node(const bNode &b_node)
 {
   return !ELEM(b_node.type,
@@ -402,6 +405,10 @@ Node *COM_convert_bnode(bNode *b_node)
       break;
     case CMP_NODE_CORNERPIN:
       node = new CornerPinNode(b_node);
+      break;
+    /* Recogni : Custom python node */
+    case CMP_NODE_PYTHON:
+      node = new PythonNode(b_node);
       break;
     case CMP_NODE_SUNBEAMS:
       node = new SunBeamsNode(b_node);

--- a/source/blender/compositor/intern/COM_ExecutionGroup.cc
+++ b/source/blender/compositor/intern/COM_ExecutionGroup.cc
@@ -516,6 +516,9 @@ bool ExecutionGroup::scheduleChunk(unsigned int chunkNumber)
   return false;
 }
 
+/* Recogni: Custom python operation requires main queue event forwarding here */
+extern "C" int wm_window_process_main_queue_events();
+
 bool ExecutionGroup::scheduleChunkWhenPossible(ExecutionSystem *graph, int xChunk, int yChunk)
 {
   if (xChunk < 0 || xChunk >= (int)this->m_x_chunks_len) {
@@ -564,6 +567,11 @@ bool ExecutionGroup::scheduleChunkWhenPossible(ExecutionSystem *graph, int xChun
 
   if (canBeExecuted) {
     scheduleChunk(chunkNumber);
+  }
+
+  if (BLI_thread_is_main()) {
+    // When Blender is run in background mode, we need to pump events manually
+    wm_window_process_main_queue_events();
   }
 
   return false;

--- a/source/blender/compositor/nodes/COM_OutputFileNode.cc
+++ b/source/blender/compositor/nodes/COM_OutputFileNode.cc
@@ -140,6 +140,9 @@ void OutputFileNode::convertToOperations(NodeConverter &converter,
                                                       sockdata->save_as_render);
         }
 
+        // recogni :: hijack skip frame counter here.
+        ((OutputSingleLayerOperation*)outputOperation)->setDisableFrameCount(sockdata->skip_frame_count);
+
         converter.addOperation(outputOperation);
         converter.mapInputSocket(input, outputOperation->getInputSocket(0));
 

--- a/source/blender/compositor/nodes/COM_OutputFileNode.cc
+++ b/source/blender/compositor/nodes/COM_OutputFileNode.cc
@@ -67,7 +67,8 @@ void OutputFileNode::convertToOperations(NodeConverter &converter,
                                                              use_half_float,
                                                              context.getViewName());
     }
-    converter.addOperation(outputOperation);
+
+    bool output_unmapped = true;
 
     int num_inputs = getNumberOfInputSockets();
     bool previewAdded = false;
@@ -78,6 +79,15 @@ void OutputFileNode::convertToOperations(NodeConverter &converter,
 
       /* note: layer becomes an empty placeholder if the input is not linked */
       outputOperation->add_layer(sockdata->layer, input->getDataType(), input->isLinked());
+
+      // recogni :: hijack skip frame counter here.
+      if (output_unmapped == true)
+      {
+        // recogni :: NOTE: The first inputs skip frame count option applies to the output node :)
+        converter.addOperation(outputOperation);
+        ((OutputSingleLayerOperation*)outputOperation)->setDisableFrameCount(sockdata->skip_frame_count);
+        output_unmapped = false;
+      }
 
       converter.mapInputSocket(input, outputOperation->getInputSocket(i));
 

--- a/source/blender/compositor/nodes/COM_PythonNode.cpp
+++ b/source/blender/compositor/nodes/COM_PythonNode.cpp
@@ -1,0 +1,30 @@
+#include "COM_PythonNode.h"
+
+#include "COM_PythonOperation.h"
+#include "BKE_global.h"
+#include "BKE_main.h"
+#include "BLI_path_util.h"
+
+PythonNode::PythonNode(bNode *editorNode) : Node(editorNode)
+{
+	/* pass */
+}
+
+void PythonNode::convertToOperations(NodeConverter &converter, const CompositorContext &context) const
+{
+	const NodePython* rna = (NodePython*)getbNode()->storage;
+
+	char absolute[FILE_MAX] = { 0 };
+	strcpy(absolute, rna->filepath);
+	BLI_path_abs(absolute, G.main->name);
+
+	PythonOperation *operation = new PythonOperation();
+	operation->setData(rna);
+	operation->setPath(absolute);
+
+	converter.addOperation(operation);
+	for (int i = 0; i < COM_PYTHON_INPUT_IMAGES + COM_PYTHON_INPUT_VALUES; i++) {
+		converter.mapInputSocket(getInputSocket(i), operation->getInputSocket(i));
+	}
+	converter.mapOutputSocket(getOutputSocket(0), operation->getOutputSocket(0));
+}

--- a/source/blender/compositor/nodes/COM_PythonNode.h
+++ b/source/blender/compositor/nodes/COM_PythonNode.h
@@ -1,0 +1,12 @@
+#ifndef _COM_PythonNode_h_
+#define _COM_PythonNode_h_
+
+#include "COM_Node.h"
+
+class PythonNode : public Node {
+public:
+	PythonNode(bNode *editorNode);
+	void convertToOperations(NodeConverter &converter, const CompositorContext &context) const;
+};
+
+#endif // _COM_PythonNode_h_

--- a/source/blender/compositor/nodes/COM_RecogniObjectIDNode.cpp
+++ b/source/blender/compositor/nodes/COM_RecogniObjectIDNode.cpp
@@ -28,10 +28,11 @@ RecogniObjectIDNode::RecogniObjectIDNode(bNode *editorNode) : Node(editorNode)
 void RecogniObjectIDNode::convertToOperations(NodeConverter &converter,
                                      const CompositorContext & /*context*/) const
 {
+  NodeInput *inputSock = this->getInputSocket(0);
+  NodeOutput *outputSock = this->getOutputSocket(0);
   RecogniObjectIDOperation *operation = new RecogniObjectIDOperation();
-  bNode *node = this->getbNode();
-  converter.addOperation(operation);
 
-  converter.mapInputSocket(getInputSocket(0), operation->getInputSocket(0));
-  converter.mapOutputSocket(getOutputSocket(0), operation->getOutputSocket(0));
+  converter.addOperation(operation);
+  converter.mapInputSocket(inputSock, operation->getInputSocket(0));
+  converter.mapOutputSocket(outputSock, operation->getOutputSocket(0));
 }

--- a/source/blender/compositor/nodes/COM_RecogniObjectIDNode.cpp
+++ b/source/blender/compositor/nodes/COM_RecogniObjectIDNode.cpp
@@ -1,0 +1,37 @@
+/*
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ * Copyright 2011, Blender Foundation.
+ */
+
+#include "COM_RecogniObjectIDNode.h"
+#include "COM_RecogniObjectIDOperation.h"
+#include "COM_ExecutionSystem.h"
+#include "BKE_node.h"
+
+RecogniObjectIDNode::RecogniObjectIDNode(bNode *editorNode) : Node(editorNode)
+{
+}
+
+void RecogniObjectIDNode::convertToOperations(NodeConverter &converter,
+                                     const CompositorContext & /*context*/) const
+{
+  RecogniObjectIDOperation *operation = new RecogniObjectIDOperation();
+  bNode *node = this->getbNode();
+  converter.addOperation(operation);
+
+  converter.mapInputSocket(getInputSocket(0), operation->getInputSocket(0));
+  converter.mapOutputSocket(getOutputSocket(0), operation->getOutputSocket(0));
+}

--- a/source/blender/compositor/nodes/COM_RecogniObjectIDNode.h
+++ b/source/blender/compositor/nodes/COM_RecogniObjectIDNode.h
@@ -1,0 +1,34 @@
+/*
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ * Copyright 2011, Blender Foundation.
+ */
+
+#ifndef __COM_RECOGNI_OBJECTID_NODE_H__
+#define __COM_RECOGNI_OBJECTID_NODE_H__
+
+#include "COM_Node.h"
+
+/**
+ * \brief RecogniObjectIDNode
+ * \ingroup Node
+ */
+class RecogniObjectIDNode : public Node {
+ public:
+  RecogniObjectIDNode(bNode *editorNode);
+  void convertToOperations(NodeConverter &converter, const CompositorContext &context) const;
+};
+
+#endif  // __COM_RECOGNI_OBJECTID_NODE_H__

--- a/source/blender/compositor/operations/COM_OutputFileOperation.cc
+++ b/source/blender/compositor/operations/COM_OutputFileOperation.cc
@@ -229,6 +229,8 @@ OutputSingleLayerOperation::OutputSingleLayerOperation(
   this->m_format = format;
   BLI_strncpy(this->m_path, path, sizeof(this->m_path));
 
+  this->m_disableFrameCount = false;
+
   this->m_viewSettings = viewSettings;
   this->m_displaySettings = displaySettings;
   this->m_viewName = viewName;
@@ -276,7 +278,7 @@ void OutputSingleLayerOperation::deinitExecution()
                                  this->m_rd->cfra,
                                  this->m_format,
                                  (this->m_rd->scemode & R_EXTENSION) != 0,
-                                 true,
+                                 this->isFrameCountDisabled() == false,
                                  suffix);
 
     if (0 == BKE_imbuf_write(ibuf, filename, this->m_format)) {

--- a/source/blender/compositor/operations/COM_OutputFileOperation.h
+++ b/source/blender/compositor/operations/COM_OutputFileOperation.h
@@ -40,6 +40,8 @@ class OutputSingleLayerOperation : public NodeOperation {
   DataType m_datatype;
   SocketReader *m_imageInput;
 
+  bool m_disableFrameCount;
+
   const ColorManagedViewSettings *m_viewSettings;
   const ColorManagedDisplaySettings *m_displaySettings;
 
@@ -72,6 +74,16 @@ class OutputSingleLayerOperation : public NodeOperation {
   bool isFileOutputOperation() const
   {
     return true;
+  }
+
+  bool isFrameCountDisabled() const 
+  {
+    return m_disableFrameCount;
+  }
+
+  void setDisableFrameCount(const bool en)
+  {
+    m_disableFrameCount = en;
   }
 };
 

--- a/source/blender/compositor/operations/COM_OutputFileOperation.h
+++ b/source/blender/compositor/operations/COM_OutputFileOperation.h
@@ -76,7 +76,7 @@ class OutputSingleLayerOperation : public NodeOperation {
     return true;
   }
 
-  bool isFrameCountDisabled() const 
+  bool isFrameCountDisabled() const
   {
     return m_disableFrameCount;
   }

--- a/source/blender/compositor/operations/COM_PythonOperation.cpp
+++ b/source/blender/compositor/operations/COM_PythonOperation.cpp
@@ -1,0 +1,297 @@
+
+#include <string>
+#include <fstream>
+#include <vector>
+
+#include "WM_api.h"
+#include "Python.h"
+#include "numpy/arrayobject.h"
+
+#include "COM_PythonOperation.h"
+
+extern "C"
+void initCompositorPython()
+{
+	if (PyArray_API == NULL) {
+		//This does not seem to be the best way to do this...
+		if (_import_array() < 0) {
+			if (PyErr_Occurred()) {
+				PyErr_Print();
+			}
+			Py_FatalError("Can't import numpy array");
+		}
+	}
+}
+
+void fatal(const char *message)
+{
+	if (PyErr_Occurred()) {
+		PyErr_Print();
+	}
+	Py_FatalError(message);
+}
+
+PythonOperation::PythonOperation() : SingleThreadedOperation()
+{
+	for (int i = 0; i < COM_PYTHON_INPUT_IMAGES; i++) {
+		addInputSocket(COM_DT_COLOR);
+	}
+	for (int i = 0; i < COM_PYTHON_INPUT_VALUES; i++) {
+		addInputSocket(COM_DT_VALUE);
+	}
+	addOutputSocket(COM_DT_COLOR);
+	setResolutionInputSocketIndex(0);
+
+	m_data = NULL;
+}
+
+void PythonOperation::initExecution()
+{
+	SingleThreadedOperation::initExecution();
+}
+
+void PythonOperation::deinitExecution()
+{
+	SingleThreadedOperation::deinitExecution();
+}
+
+std::string readPythonFileContent(const std::string& path)
+{
+	std::ifstream input(path);
+	std::stringstream buffer;
+	buffer << input.rdbuf();
+	return buffer.str();
+}
+
+PyObject *createScriptModule(const std::string& content, const std::string& path)
+{
+	PyObject *pyModule = PyModule_New("blender_com_python");
+	if (pyModule) {
+		PyModule_AddStringConstant(pyModule, "__file__", path.c_str());
+
+		PyObject *locals = PyModule_GetDict(pyModule); //Borrowed ref
+		PyObject *builtins = PyEval_GetBuiltins(); //Borrowed ref
+		PyDict_SetItemString(locals, "__builtins__", builtins);
+
+		PyObject *pyValue = PyRun_String(content.c_str(), Py_file_input, locals, locals);
+		if (pyValue) {
+			Py_DECREF(pyValue);
+		}
+		else {
+			PyErr_Print();
+		}
+	}
+	return pyModule;
+}
+
+bool callMethod(PyObject* pyModule, const char *name, PyObject* context)
+{
+	bool ok = true; //Assume no function is defined with the given name
+
+	PyObject* callback = PyDict_GetItemString(PyModule_GetDict(pyModule), name); //Borrowed ref
+	if (callback) {
+		ok = false; //Function found
+
+		PyObject* args = Py_BuildValue("(O)", context);
+		if (args) {
+			PyObject *tmp = PyObject_CallObject(callback, args);
+			if (tmp) {
+				ok = true;
+				Py_CLEAR(tmp);
+			}
+			else {
+				PyErr_Print();
+			}
+			Py_CLEAR(args);
+		}
+		else {
+			PyErr_Print();
+		}
+	}
+	else {
+		PyErr_Print();
+	}
+	return ok;
+}
+
+void addBuffersToContext(PyObject *context, const char *name, std::vector<MemoryBuffer*> *buffers)
+{
+	const int count = buffers->size();
+	PyObject *results = PyList_New(count);
+
+	for (int i = 0; i < count; i++) {
+		MemoryBuffer *buffer = buffers->at(i);
+
+		npy_intp dims[3];
+		dims[0] = buffer->getHeight(); //Height first dimension
+		dims[1] = buffer->getWidth();
+		dims[2] = 4;
+		PyObject *arr = PyArray_SimpleNewFromData(3, dims, NPY_FLOAT32, buffer->getBuffer());
+		if (arr) {
+			PyList_SetItem(results, i, arr); //Steals ref
+		}
+		else {
+			fatal("Can't create a numpy array from a buffer");
+		}
+	}
+
+	PyDict_SetItemString(context, name, results);
+	Py_DECREF(results);
+}
+
+void addValuesToContext(PyObject *context, const char *name, std::vector<float> *values)
+{
+	const int count = values->size();
+	PyObject *results = PyList_New(count);
+
+	for (int i = 0; i < count; i++) {
+		PyObject *pyFloat = PyFloat_FromDouble(values->at(i));
+		if (pyFloat) {
+			PyList_SET_ITEM(results, i, pyFloat); //Steals ref
+		}
+		else {
+			fatal("Can't create a value float");
+		}
+	}
+
+	PyDict_SetItemString(context, name, results);
+	Py_DECREF(results);
+}
+
+void clearBuffer(MemoryBuffer *buffer)
+{
+	const float invalid[] = { 1, 0, 0, 1 };
+	const int width = buffer->getWidth();
+	const int height = buffer->getHeight();
+
+	for (int y = 0; y < height; y++) {
+		for (int x = 0; x < width; x++) {
+			buffer->writePixel(x, y, invalid);
+		}
+	}
+}
+
+struct ThreadData {
+	ThreadCondition condition;
+	ThreadMutex *mutex;
+
+	PyObject *context;
+	PyObject *pyModule;
+	std::string scriptPath;
+	std::string scriptContent;
+	bool startOk;
+};
+
+void pythonMainThreadCallback(void* userData)
+{
+	BLI_assert(BLI_thread_is_main());
+
+	PyGILState_STATE gstate = PyGILState_Ensure();
+
+	ThreadData* data = (ThreadData*)userData;
+
+	data->pyModule = createScriptModule(data->scriptContent, data->scriptPath);
+	if (data->pyModule) {
+		data->startOk = callMethod(data->pyModule, "on_main", data->context);
+	}
+	PyGILState_Release(gstate);
+
+	BLI_condition_notify_all(&data->condition);
+}
+
+MemoryBuffer *PythonOperation::createMemoryBuffer(rcti *source)
+{
+	rcti rect;
+	rect.xmin = 0;
+	rect.ymin = 0;
+	rect.xmax = source->xmax;
+	rect.ymax = source->ymax;
+	MemoryBuffer *result = new MemoryBuffer(COM_DT_COLOR, &rect);
+
+	std::vector<MemoryBuffer*> inputs;
+	for (int i = 0; i < COM_PYTHON_INPUT_IMAGES; i++) {
+		MemoryBuffer *tile = (MemoryBuffer*)getInputSocketReader(i)->initializeTileData(source);
+		inputs.push_back(tile);
+	}
+
+	std::vector<MemoryBuffer*> outputs;
+	outputs.push_back(result);
+
+	for (int i = 0; i < outputs.size(); i++) {
+		clearBuffer(outputs[i]);
+	}
+
+	const std::string content = readPythonFileContent(m_path);
+
+	// Script import and main callback
+	PyGILState_STATE gstate;
+	gstate = PyGILState_Ensure();
+
+	PyObject* context = PyDict_New();
+	addBuffersToContext(context, "images", &inputs);
+	addBuffersToContext(context, "outputs", &outputs);
+
+	std::vector<float> values;
+	float value[4] = { 0 };
+	for (int i = 0; i < COM_PYTHON_INPUT_VALUES; i++) {
+		getInputSocketReader(COM_PYTHON_INPUT_IMAGES + i)->readSampled(value, 0, 0, COM_PS_NEAREST);
+		values.push_back(value[0]);
+	}
+	addValuesToContext(context, "inputs", &values);
+
+	PyGILState_Release(gstate);
+
+	ThreadData threadData;
+	threadData.condition = {};
+	threadData.mutex = BLI_mutex_alloc();
+	BLI_condition_init(&threadData.condition);
+
+	threadData.context = context;
+	threadData.pyModule = NULL;
+	threadData.scriptContent = content;
+	threadData.scriptPath = m_path;
+	threadData.startOk = false;
+
+	// Run Python init in the main thread and wait until it is ready
+	WM_run_in_main_thread(pythonMainThreadCallback, &threadData);
+	BLI_condition_wait(&threadData.condition, threadData.mutex);
+
+	// Async callback
+	gstate = PyGILState_Ensure();
+
+	bool endOk = false;
+	if (threadData.pyModule) {
+		endOk = callMethod(threadData.pyModule, "on_async", context);
+	}
+	Py_CLEAR(context);
+	Py_CLEAR(threadData.pyModule);
+
+	PyGILState_Release(gstate);
+
+	if (!threadData.startOk || !endOk) {
+		// A callback failed, erase all output buffers
+		for (int i = 0; i < outputs.size(); i++) {
+			clearBuffer(outputs[i]);
+		}
+	}
+
+	BLI_condition_end(&threadData.condition);
+	BLI_mutex_free(threadData.mutex);
+
+	return result;
+}
+
+bool PythonOperation::determineDependingAreaOfInterest(rcti * /*input*/, ReadBufferOperation *readOperation, rcti *output)
+{
+	if (isCached()) {
+		return false;
+	}
+	else {
+		rcti newInput;
+		newInput.xmin = 0;
+		newInput.ymin = 0;
+		newInput.xmax = getWidth();
+		newInput.ymax = getHeight();
+		return NodeOperation::determineDependingAreaOfInterest(&newInput, readOperation, output);
+	}
+}

--- a/source/blender/compositor/operations/COM_PythonOperation.h
+++ b/source/blender/compositor/operations/COM_PythonOperation.h
@@ -1,0 +1,32 @@
+
+#ifndef _COM_PythonOperation_h_
+#define _COM_PythonOperation_h_
+
+#include <string>
+
+#include "COM_NodeOperation.h"
+#include "COM_SingleThreadedOperation.h"
+
+#define COM_PYTHON_INPUT_IMAGES 4
+#define COM_PYTHON_INPUT_VALUES 8
+
+class PythonOperation : public SingleThreadedOperation {
+private:
+	const NodePython *m_data;
+	std::string m_path;
+public:
+	PythonOperation();
+
+	void initExecution();
+	void deinitExecution();
+	bool determineDependingAreaOfInterest(rcti *input, ReadBufferOperation *readOperation, rcti *output);
+
+	void setData(const NodePython *data) { this->m_data = data; }
+	void setPath(const std::string& path) { this->m_path = path; }
+
+protected:
+
+	MemoryBuffer *createMemoryBuffer(rcti *rect);
+};
+
+#endif

--- a/source/blender/compositor/operations/COM_RecogniObjectIDOperation.cpp
+++ b/source/blender/compositor/operations/COM_RecogniObjectIDOperation.cpp
@@ -22,9 +22,11 @@ RecogniObjectIDOperation::RecogniObjectIDOperation() : NodeOperation()
 {
   this->addInputSocket(COM_DT_VALUE);
   this->addOutputSocket(COM_DT_COLOR);
+  
   this->m_inputValueProgram = NULL;
-  setResolutionInputSocketIndex(1);
+  setResolutionInputSocketIndex(0);
 }
+
 void RecogniObjectIDOperation::initExecution()
 {
   this->m_inputValueProgram = this->getInputSocketReader(0);

--- a/source/blender/compositor/operations/COM_RecogniObjectIDOperation.cpp
+++ b/source/blender/compositor/operations/COM_RecogniObjectIDOperation.cpp
@@ -43,17 +43,17 @@ void RecogniObjectIDOperation::executePixelSampled(float output[4], float x, flo
   const int value = int(oid[0]);
   
   /*
-   *  The top 8 bits of the value represent the ClassID.
-   *  The bottom 16 bits of the value represent the InstanceID.
-   *  The alpha channel is always set to 1.0.
-   *  ClassID and InstanceID of 0 is reserved for the background.
+   *  The top 8 bits of the value represent the InstanceID.
+   *  The bottom 8 bits of the value represent the ClassID.
+   *  The alpha channel is always set to 1.0 and the red channel is always set 
+   *  to 0.0.
    */
-  const uint classID = ((uint)(value >> 16)) & 0xFF;
-  const uint instanceID = ((uint)value) & 0xFFFF;
+  const uint instanceId = ((uint)(value >> 8)) & 0xFF;
+  const uint classId = ((uint)value) & 0xFF;
 
-  output[0] = ((float)classID) / 256.0f; 
-  output[1] = (((float)((instanceID >> 8) & 0xFF))) / 256.0f;
-  output[2] = (((float)((instanceID >> 0) & 0xFF))) / 256.0f;
+  output[0] = 0.0f;
+  output[1] = ((float)instanceId) / 256.0f;
+  output[2] = ((float)classId) / 256.0f;
   output[3] = 1.0f;
 }
 

--- a/source/blender/compositor/operations/COM_RecogniObjectIDOperation.cpp
+++ b/source/blender/compositor/operations/COM_RecogniObjectIDOperation.cpp
@@ -1,0 +1,61 @@
+/*
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ * Copyright 2011, Blender Foundation.
+ */
+
+#include "COM_RecogniObjectIDOperation.h"
+
+RecogniObjectIDOperation::RecogniObjectIDOperation() : NodeOperation()
+{
+  this->addInputSocket(COM_DT_VALUE);
+  this->addOutputSocket(COM_DT_COLOR);
+  this->m_inputValueProgram = NULL;
+  setResolutionInputSocketIndex(1);
+}
+void RecogniObjectIDOperation::initExecution()
+{
+  this->m_inputValueProgram = this->getInputSocketReader(0);
+}
+
+void RecogniObjectIDOperation::executePixelSampled(float output[4], float x, float y, PixelSampler sampler)
+{
+  /*
+   *  Sample the input value which should be the object id information which
+   *  is replicated across all channels - we grab it from channel 0 to be safe.
+   */
+  float oid[4];
+  this->m_inputValueProgram->readSampled(oid, x, y, sampler);
+  const int value = int(oid[0]);
+  
+  /*
+   *  The top 8 bits of the value represent the ClassID.
+   *  The bottom 16 bits of the value represent the InstanceID.
+   *  The alpha channel is always set to 1.0.
+   *  ClassID and InstanceID of 0 is reserved for the background.
+   */
+  const uint classID = ((uint)(value >> 16)) & 0xFF;
+  const uint instanceID = ((uint)value) & 0xFFFF;
+
+  output[0] = ((float)classID) / 256.0f; 
+  output[1] = (((float)((instanceID >> 8) & 0xFF))) / 256.0f;
+  output[2] = (((float)((instanceID >> 0) & 0xFF))) / 256.0f;
+  output[3] = 1.0f;
+}
+
+void RecogniObjectIDOperation::deinitExecution()
+{
+  this->m_inputValueProgram = NULL;
+}

--- a/source/blender/compositor/operations/COM_RecogniObjectIDOperation.h
+++ b/source/blender/compositor/operations/COM_RecogniObjectIDOperation.h
@@ -1,0 +1,48 @@
+/*
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ * Copyright 2011, Blender Foundation.
+ */
+
+#ifndef __COM_RECOGNI_OBJECTID_OPERATION_H__
+#define __COM_RECOGNI_OBJECTID_OPERATION_H__
+#include "COM_NodeOperation.h"
+
+class RecogniObjectIDOperation : public NodeOperation {
+ private:
+  /**
+   * Cached reference to the inputProgram
+   */
+  SocketReader *m_inputValueProgram;
+  
+ public:
+  RecogniObjectIDOperation();
+
+  /**
+   * the inner loop of this program
+   */
+  void executePixelSampled(float output[4], float x, float y, PixelSampler sampler);
+
+  /**
+   * Initialize the execution
+   */
+  void initExecution();
+
+  /**
+   * Deinitialize the execution
+   */
+  void deinitExecution();
+};
+#endif

--- a/source/blender/editors/space_node/drawnode.c
+++ b/source/blender/editors/space_node/drawnode.c
@@ -2527,6 +2527,15 @@ static void node_composit_buts_python(uiLayout *layout, bContext *UNUSED(C), Poi
   uiItemR(layout, ptr, "filepath", 0, "", ICON_NONE);
 }
 
+static void node_composit_buts_reobjid(uiLayout *layout, bContext *UNUSED(C), PointerRNA *ptr)
+{
+  // uiLayout *col;
+  // col = uiLayoutColumn(layout, false);
+  // uiItemR(col, ptr, "invert_rgb", 0, NULL, ICON_NONE);
+  // uiItemR(col, ptr, "invert_alpha", 0, NULL, ICON_NONE);
+}
+
+
 static void node_composit_buts_mask(uiLayout *layout, bContext *C, PointerRNA *ptr)
 {
   bNode *node = ptr->data;
@@ -2985,11 +2994,6 @@ static void node_composit_set_butfunc(bNodeType *ntype)
     case CMP_NODE_SUNBEAMS:
       ntype->draw_buttons = node_composit_buts_sunbeams;
       break;
-    /* Recogni: Custom python node */
-    case CMP_NODE_PYTHON:
-      ntype->draw_buttons = node_composit_buts_python;
-      ntype->width += 50;
-      break;
     case CMP_NODE_CRYPTOMATTE:
       ntype->draw_buttons = node_composit_buts_cryptomatte;
       break;
@@ -3003,6 +3007,16 @@ static void node_composit_set_butfunc(bNodeType *ntype)
     case CMP_NODE_DENOISE:
       ntype->draw_buttons = node_composit_buts_denoise;
       break;
+
+    /* Recogni: Custom python node */
+    case CMP_NODE_PYTHON:
+      ntype->draw_buttons = node_composit_buts_python;
+      ntype->width += 50;
+      break;
+    case CMP_NODE_RECOGNI_OBJECT_ID:
+      ntype->draw_buttons = node_composit_buts_reobjid;
+      break;
+
   }
 }
 

--- a/source/blender/editors/space_node/drawnode.c
+++ b/source/blender/editors/space_node/drawnode.c
@@ -2518,6 +2518,15 @@ static void node_composit_buts_viewer_ex(uiLayout *layout, bContext *UNUSED(C), 
   }
 }
 
+/*
+ *  Recogni: Custom python node.
+ */
+static void node_composit_buts_python(uiLayout *layout, bContext *UNUSED(C), PointerRNA *ptr)
+{
+  uiItemL(layout, IFACE_("Script file:"), ICON_NONE);
+  uiItemR(layout, ptr, "filepath", 0, "", ICON_NONE);
+}
+
 static void node_composit_buts_mask(uiLayout *layout, bContext *C, PointerRNA *ptr)
 {
   bNode *node = ptr->data;
@@ -2975,6 +2984,11 @@ static void node_composit_set_butfunc(bNodeType *ntype)
       break;
     case CMP_NODE_SUNBEAMS:
       ntype->draw_buttons = node_composit_buts_sunbeams;
+      break;
+    /* Recogni: Custom python node */
+    case CMP_NODE_PYTHON:
+      ntype->draw_buttons = node_composit_buts_python;
+      ntype->width += 50;
       break;
     case CMP_NODE_CRYPTOMATTE:
       ntype->draw_buttons = node_composit_buts_cryptomatte;

--- a/source/blender/editors/space_node/drawnode.c
+++ b/source/blender/editors/space_node/drawnode.c
@@ -1997,6 +1997,7 @@ static void node_composit_buts_file_output_ex(uiLayout *layout, bContext *C, Poi
       if ((!is_exr && use_node_format) || (!is_socket_exr && !use_node_format)) {
         uiItemR(col, &active_input_ptr, "save_as_render", DEFAULT_FLAGS, NULL, ICON_NONE);
       }
+      uiItemR(col, &active_input_ptr, "skip_frame_count", 0, NULL, ICON_NONE);
 
       col = uiLayoutColumn(layout, false);
       uiLayoutSetActive(col, use_node_format == false);

--- a/source/blender/makesdna/DNA_node_types.h
+++ b/source/blender/makesdna/DNA_node_types.h
@@ -744,7 +744,8 @@ typedef struct NodeImageMultiFileSocket {
   /** Use overall node image format. */
   short use_node_format;
   char save_as_render;
-  char _pad1[3];
+  char _pad1[1];
+  short skip_frame_count;
   /** 1024 = FILE_MAX. */
   char path[1024];
   ImageFormatData format;

--- a/source/blender/makesdna/DNA_node_types.h
+++ b/source/blender/makesdna/DNA_node_types.h
@@ -1049,9 +1049,16 @@ typedef struct NodeShaderTexIES {
   char filepath[1024];
 } NodeShaderTexIES;
 
+<<<<<<< HEAD
 typedef struct NodeShaderOutputAOV {
   char name[64];
 } NodeShaderOutputAOV;
+=======
+/* Recogni: Custom python node */
+typedef struct NodePython {
+  char filepath[1024]; /* 1024 = FILE_MAX */
+} NodePython;
+>>>>>>> 0cab23f846e... Update gitmodules to use https clone path
 
 typedef struct NodeSunBeams {
   float source[2];

--- a/source/blender/makesdna/DNA_node_types.h
+++ b/source/blender/makesdna/DNA_node_types.h
@@ -1049,16 +1049,14 @@ typedef struct NodeShaderTexIES {
   char filepath[1024];
 } NodeShaderTexIES;
 
-<<<<<<< HEAD
 typedef struct NodeShaderOutputAOV {
   char name[64];
 } NodeShaderOutputAOV;
-=======
+
 /* Recogni: Custom python node */
 typedef struct NodePython {
   char filepath[1024]; /* 1024 = FILE_MAX */
 } NodePython;
->>>>>>> 0cab23f846e... Update gitmodules to use https clone path
 
 typedef struct NodeSunBeams {
   float source[2];

--- a/source/blender/makesrna/intern/rna_nodetree.c
+++ b/source/blender/makesrna/intern/rna_nodetree.c
@@ -8533,19 +8533,6 @@ static void def_cmp_sunbeams(StructRNA *srna)
   RNA_def_property_update(prop, NC_NODE | NA_EDITED, "rna_Node_update");
 }
 
-/* Recogni: Custom python node */
-static void def_cmp_python(StructRNA *srna)
-{
-  PropertyRNA *prop;
-
-  RNA_def_struct_sdna_from(srna, "NodePython", "storage");
-
-  prop = RNA_def_property(srna, "filepath", PROP_STRING, PROP_FILEPATH);
-  RNA_def_property_string_sdna(prop, NULL, "filepath");
-  RNA_def_property_ui_text(prop, "Script file", "");
-  RNA_def_property_update(prop, NC_NODE | NA_EDITED, "rna_Node_update");
-}
-
 static void def_cmp_cryptomatte_entry(BlenderRNA *brna)
 {
   StructRNA *srna;
@@ -8674,6 +8661,36 @@ static void def_cmp_denoise(StructRNA *srna)
   RNA_def_property_boolean_sdna(prop, NULL, "hdr", 0);
   RNA_def_property_ui_text(prop, "HDR", "Process HDR images");
   RNA_def_property_update(prop, NC_NODE | NA_EDITED, "rna_Node_update");
+}
+
+/*
+ *  Recogni: Custom python nodes
+ */
+static void def_cmp_python(StructRNA *srna)
+{
+  PropertyRNA *prop;
+
+  RNA_def_struct_sdna_from(srna, "NodePython", "storage");
+
+  prop = RNA_def_property(srna, "filepath", PROP_STRING, PROP_FILEPATH);
+  RNA_def_property_string_sdna(prop, NULL, "filepath");
+  RNA_def_property_ui_text(prop, "Script file", "");
+  RNA_def_property_update(prop, NC_NODE | NA_EDITED, "rna_Node_update");
+}
+
+static void def_cmp_recogni_oid(StructRNA *srna)
+{
+  // PropertyRNA *prop;
+
+  // prop = RNA_def_property(srna, "invert_rgb", PROP_BOOLEAN, PROP_NONE);
+  // RNA_def_property_boolean_sdna(prop, NULL, "custom1", CMP_CHAN_RGB);
+  // RNA_def_property_ui_text(prop, "RGB", "");
+  // RNA_def_property_update(prop, NC_NODE | NA_EDITED, "rna_Node_update");
+
+  // prop = RNA_def_property(srna, "invert_alpha", PROP_BOOLEAN, PROP_NONE);
+  // RNA_def_property_boolean_sdna(prop, NULL, "custom1", CMP_CHAN_A);
+  // RNA_def_property_ui_text(prop, "Alpha", "");
+  // RNA_def_property_update(prop, NC_NODE | NA_EDITED, "rna_Node_update");
 }
 
 /* -- Texture Nodes --------------------------------------------------------- */

--- a/source/blender/makesrna/intern/rna_nodetree.c
+++ b/source/blender/makesrna/intern/rna_nodetree.c
@@ -8533,6 +8533,19 @@ static void def_cmp_sunbeams(StructRNA *srna)
   RNA_def_property_update(prop, NC_NODE | NA_EDITED, "rna_Node_update");
 }
 
+/* Recogni: Custom python node */
+static void def_cmp_python(StructRNA *srna)
+{
+  PropertyRNA *prop;
+
+  RNA_def_struct_sdna_from(srna, "NodePython", "storage");
+
+  prop = RNA_def_property(srna, "filepath", PROP_STRING, PROP_FILEPATH);
+  RNA_def_property_string_sdna(prop, NULL, "filepath");
+  RNA_def_property_ui_text(prop, "Script file", "");
+  RNA_def_property_update(prop, NC_NODE | NA_EDITED, "rna_Node_update");
+}
+
 static void def_cmp_cryptomatte_entry(BlenderRNA *brna)
 {
   StructRNA *srna;

--- a/source/blender/makesrna/intern/rna_nodetree.c
+++ b/source/blender/makesrna/intern/rna_nodetree.c
@@ -6477,6 +6477,11 @@ static void rna_def_cmp_output_file_slot_file(BlenderRNA *brna)
       prop, "Save as Render", "Apply render part of display transform when saving byte image");
   RNA_def_property_update(prop, NC_NODE | NA_EDITED, NULL);
 
+  prop = RNA_def_property(srna, "skip_frame_count", PROP_BOOLEAN, PROP_NONE);
+  RNA_def_property_boolean_sdna(prop, NULL, "skip_frame_count", 0);
+  RNA_def_property_ui_text(prop, "Skip Frame Count", "");
+  RNA_def_property_update(prop, NC_NODE | NA_EDITED, NULL);
+
   prop = RNA_def_property(srna, "format", PROP_POINTER, PROP_NONE);
   RNA_def_property_struct_type(prop, "ImageFormatSettings");
 

--- a/source/blender/nodes/CMakeLists.txt
+++ b/source/blender/nodes/CMakeLists.txt
@@ -58,6 +58,7 @@ set(SRC
   composite/nodes/node_composite_colorSpill.c
   composite/nodes/node_composite_colorbalance.c
   composite/nodes/node_composite_colorcorrection.c
+  composite/nodes/node_composite_python.c
   composite/nodes/node_composite_common.c
   composite/nodes/node_composite_composite.c
   composite/nodes/node_composite_cornerpin.c

--- a/source/blender/nodes/CMakeLists.txt
+++ b/source/blender/nodes/CMakeLists.txt
@@ -59,6 +59,7 @@ set(SRC
   composite/nodes/node_composite_colorbalance.c
   composite/nodes/node_composite_colorcorrection.c
   composite/nodes/node_composite_python.c
+  composite/nodes/node_composite_recogni_object_id.c
   composite/nodes/node_composite_common.c
   composite/nodes/node_composite_composite.c
   composite/nodes/node_composite_cornerpin.c

--- a/source/blender/nodes/NOD_composite.h
+++ b/source/blender/nodes/NOD_composite.h
@@ -139,6 +139,7 @@ void register_node_type_cmp_cornerpin(void);
 
 /* Recogni: Custom python node */
 void register_node_type_cmp_python(void);
+void register_node_type_cmp_recogni_object_id(void);
 
 void node_cmp_rlayers_outputs(struct bNodeTree *ntree, struct bNode *node);
 void node_cmp_rlayers_register_pass(struct bNodeTree *ntree,

--- a/source/blender/nodes/NOD_composite.h
+++ b/source/blender/nodes/NOD_composite.h
@@ -137,6 +137,9 @@ void register_node_type_cmp_trackpos(void);
 void register_node_type_cmp_planetrackdeform(void);
 void register_node_type_cmp_cornerpin(void);
 
+/* Recogni: Custom python node */
+void register_node_type_cmp_python(void);
+
 void node_cmp_rlayers_outputs(struct bNodeTree *ntree, struct bNode *node);
 void node_cmp_rlayers_register_pass(struct bNodeTree *ntree,
                                     struct bNode *node,

--- a/source/blender/nodes/NOD_static_types.h
+++ b/source/blender/nodes/NOD_static_types.h
@@ -220,6 +220,7 @@ DefNode(CompositorNode, CMP_NODE_PIXELATE,       0,                      "PIXELA
 DefNode(CompositorNode, CMP_NODE_PLANETRACKDEFORM,def_cmp_planetrackdeform,"PLANETRACKDEFORM",PlaneTrackDeform,"Plane Track Deform",""            )
 DefNode(CompositorNode, CMP_NODE_CORNERPIN,      0,                      "CORNERPIN",      CornerPin,        "Corner Pin",        ""              )
 DefNode(CompositorNode, CMP_NODE_SUNBEAMS,       def_cmp_sunbeams,       "SUNBEAMS",       SunBeams,         "Sun Beams",         ""              )
+DefNode(CompositorNode, CMP_NODE_PYTHON,         def_cmp_python, 	     "PYTHON",         Python,           "Python Script",     ""              )
 DefNode(CompositorNode, CMP_NODE_CRYPTOMATTE,    def_cmp_cryptomatte,    "CRYPTOMATTE_V2", CryptomatteV2,    "Cryptomatte",       ""              )
 DefNode(CompositorNode, CMP_NODE_CRYPTOMATTE_LEGACY, def_cmp_cryptomatte_legacy, "CRYPTOMATTE", Cryptomatte, "Cryptomatte (Legacy)", ""           )
 DefNode(CompositorNode, CMP_NODE_DENOISE,        def_cmp_denoise,        "DENOISE",        Denoise,          "Denoise",           ""              )

--- a/source/blender/nodes/NOD_static_types.h
+++ b/source/blender/nodes/NOD_static_types.h
@@ -220,11 +220,14 @@ DefNode(CompositorNode, CMP_NODE_PIXELATE,       0,                      "PIXELA
 DefNode(CompositorNode, CMP_NODE_PLANETRACKDEFORM,def_cmp_planetrackdeform,"PLANETRACKDEFORM",PlaneTrackDeform,"Plane Track Deform",""            )
 DefNode(CompositorNode, CMP_NODE_CORNERPIN,      0,                      "CORNERPIN",      CornerPin,        "Corner Pin",        ""              )
 DefNode(CompositorNode, CMP_NODE_SUNBEAMS,       def_cmp_sunbeams,       "SUNBEAMS",       SunBeams,         "Sun Beams",         ""              )
-DefNode(CompositorNode, CMP_NODE_PYTHON,         def_cmp_python, 	     "PYTHON",         Python,           "Python Script",     ""              )
 DefNode(CompositorNode, CMP_NODE_CRYPTOMATTE,    def_cmp_cryptomatte,    "CRYPTOMATTE_V2", CryptomatteV2,    "Cryptomatte",       ""              )
 DefNode(CompositorNode, CMP_NODE_CRYPTOMATTE_LEGACY, def_cmp_cryptomatte_legacy, "CRYPTOMATTE", Cryptomatte, "Cryptomatte (Legacy)", ""           )
 DefNode(CompositorNode, CMP_NODE_DENOISE,        def_cmp_denoise,        "DENOISE",        Denoise,          "Denoise",           ""              )
 DefNode(CompositorNode, CMP_NODE_EXPOSURE,       0,                      "EXPOSURE",       Exposure,         "Exposure",          ""              )
+
+/* Recogni custom nodes */
+DefNode(CompositorNode, CMP_NODE_PYTHON,         def_cmp_python, 	     "PYTHON",         Python,           "Python Script",     ""              )
+DefNode(CompositorNode, CMP_NODE_RECOGNI_OBJECT_ID, def_cmp_recogni_oid,  "REOBJECTID",     RecogniObjectID,  "Recogni Object ID", ""              )
 
 DefNode(TextureNode,    TEX_NODE_OUTPUT,         def_tex_output,         "OUTPUT",         Output,           "Output",            ""              )
 DefNode(TextureNode,    TEX_NODE_CHECKER,        0,                      "CHECKER",        Checker,          "Checker",           ""              )

--- a/source/blender/nodes/composite/nodes/node_composite_outputFile.c
+++ b/source/blender/nodes/composite/nodes/node_composite_outputFile.c
@@ -147,6 +147,9 @@ bNodeSocket *ntreeCompositOutputFileAddSocket(bNodeTree *ntree,
   /* use node data format by default */
   sockdata->use_node_format = true;
   sockdata->save_as_render = true;
+  
+  /* recogni :: always add frame count by default : preserve legacy behavior */
+  sockdata->skip_frame_count = false;
 
   nimf->active_input = BLI_findindex(&node->inputs, sock);
 

--- a/source/blender/nodes/composite/nodes/node_composite_python.c
+++ b/source/blender/nodes/composite/nodes/node_composite_python.c
@@ -1,24 +1,24 @@
 #include "node_composite_util.h"
 
 static bNodeSocketTemplate cmp_node_python_in[] = {
-	{ SOCK_RGBA,  1, N_("Image 0"),      1.0f, 1.0f, 1.0f, 1.0f },
-	{ SOCK_RGBA,  1, N_("Image 1"),      1.0f, 1.0f, 1.0f, 1.0f },
-	{ SOCK_RGBA,  1, N_("Image 2"),      1.0f, 1.0f, 1.0f, 1.0f },
-	{ SOCK_RGBA,  1, N_("Image 3"),      1.0f, 1.0f, 1.0f, 1.0f },
-	{ SOCK_FLOAT, 1, N_("Input 0"),	     0.0f, 0.0f, 0.0f, 0.0f, 0.0f, FLT_MAX },
-	{ SOCK_FLOAT, 1, N_("Input 1"),	     0.0f, 0.0f, 0.0f, 0.0f, 0.0f, FLT_MAX },
-	{ SOCK_FLOAT, 1, N_("Input 2"),	     0.0f, 0.0f, 0.0f, 0.0f, 0.0f, FLT_MAX },
-	{ SOCK_FLOAT, 1, N_("Input 3"),	     0.0f, 0.0f, 0.0f, 0.0f, 0.0f, FLT_MAX },
-	{ SOCK_FLOAT, 1, N_("Input 4"),	     0.0f, 0.0f, 0.0f, 0.0f, 0.0f, FLT_MAX },
-	{ SOCK_FLOAT, 1, N_("Input 5"),	     0.0f, 0.0f, 0.0f, 0.0f, 0.0f, FLT_MAX },
-	{ SOCK_FLOAT, 1, N_("Input 6"),	     0.0f, 0.0f, 0.0f, 0.0f, 0.0f, FLT_MAX },
-	{ SOCK_FLOAT, 1, N_("Input 7"),	     0.0f, 0.0f, 0.0f, 0.0f, 0.0f, FLT_MAX },
-	{ -1, 0, "" }
+	{ SOCK_RGBA,  N_("Image 0"),      1.0f, 1.0f, 1.0f, 1.0f },
+	{ SOCK_RGBA,  N_("Image 1"),      1.0f, 1.0f, 1.0f, 1.0f },
+	{ SOCK_RGBA,  N_("Image 2"),      1.0f, 1.0f, 1.0f, 1.0f },
+	{ SOCK_RGBA,  N_("Image 3"),      1.0f, 1.0f, 1.0f, 1.0f },
+	{ SOCK_FLOAT, N_("Input 0"),      0.0f, 0.0f, 0.0f, 0.0f, 0.0f, FLT_MAX },
+	{ SOCK_FLOAT, N_("Input 1"),      0.0f, 0.0f, 0.0f, 0.0f, 0.0f, FLT_MAX },
+	{ SOCK_FLOAT, N_("Input 2"),      0.0f, 0.0f, 0.0f, 0.0f, 0.0f, FLT_MAX },
+	{ SOCK_FLOAT, N_("Input 3"),      0.0f, 0.0f, 0.0f, 0.0f, 0.0f, FLT_MAX },
+	{ SOCK_FLOAT, N_("Input 4"),      0.0f, 0.0f, 0.0f, 0.0f, 0.0f, FLT_MAX },
+	{ SOCK_FLOAT, N_("Input 5"),      0.0f, 0.0f, 0.0f, 0.0f, 0.0f, FLT_MAX },
+	{ SOCK_FLOAT, N_("Input 6"),      0.0f, 0.0f, 0.0f, 0.0f, 0.0f, FLT_MAX },
+	{ SOCK_FLOAT, N_("Input 7"),      0.0f, 0.0f, 0.0f, 0.0f, 0.0f, FLT_MAX },
+	{ -1, "" }
 };
 
 static bNodeSocketTemplate cmp_node_python_out[] = {
-	{ SOCK_RGBA, 0, N_("Output 0") },
-	{ -1, 0, "" }
+	{ SOCK_RGBA, N_("Output 0") },
+	{ -1, "" }
 };
 
 static void node_composit_init_python(bNodeTree *UNUSED(ntree), bNode *node)

--- a/source/blender/nodes/composite/nodes/node_composite_python.c
+++ b/source/blender/nodes/composite/nodes/node_composite_python.c
@@ -1,0 +1,42 @@
+#include "node_composite_util.h"
+
+static bNodeSocketTemplate cmp_node_python_in[] = {
+	{ SOCK_RGBA,  1, N_("Image 0"),      1.0f, 1.0f, 1.0f, 1.0f },
+	{ SOCK_RGBA,  1, N_("Image 1"),      1.0f, 1.0f, 1.0f, 1.0f },
+	{ SOCK_RGBA,  1, N_("Image 2"),      1.0f, 1.0f, 1.0f, 1.0f },
+	{ SOCK_RGBA,  1, N_("Image 3"),      1.0f, 1.0f, 1.0f, 1.0f },
+	{ SOCK_FLOAT, 1, N_("Input 0"),	     0.0f, 0.0f, 0.0f, 0.0f, 0.0f, FLT_MAX },
+	{ SOCK_FLOAT, 1, N_("Input 1"),	     0.0f, 0.0f, 0.0f, 0.0f, 0.0f, FLT_MAX },
+	{ SOCK_FLOAT, 1, N_("Input 2"),	     0.0f, 0.0f, 0.0f, 0.0f, 0.0f, FLT_MAX },
+	{ SOCK_FLOAT, 1, N_("Input 3"),	     0.0f, 0.0f, 0.0f, 0.0f, 0.0f, FLT_MAX },
+	{ SOCK_FLOAT, 1, N_("Input 4"),	     0.0f, 0.0f, 0.0f, 0.0f, 0.0f, FLT_MAX },
+	{ SOCK_FLOAT, 1, N_("Input 5"),	     0.0f, 0.0f, 0.0f, 0.0f, 0.0f, FLT_MAX },
+	{ SOCK_FLOAT, 1, N_("Input 6"),	     0.0f, 0.0f, 0.0f, 0.0f, 0.0f, FLT_MAX },
+	{ SOCK_FLOAT, 1, N_("Input 7"),	     0.0f, 0.0f, 0.0f, 0.0f, 0.0f, FLT_MAX },
+	{ -1, 0, "" }
+};
+
+static bNodeSocketTemplate cmp_node_python_out[] = {
+	{ SOCK_RGBA, 0, N_("Output 0") },
+	{ -1, 0, "" }
+};
+
+static void node_composit_init_python(bNodeTree *UNUSED(ntree), bNode *node)
+{
+	NodePython *data = MEM_callocN(sizeof(NodePython), "python node");
+	memset(data->filepath, 0, sizeof(data->filepath));
+
+	node->storage = data;
+}
+
+void register_node_type_cmp_python(void)
+{
+	static bNodeType ntype;
+
+	cmp_node_type_base(&ntype, CMP_NODE_PYTHON, "Python Script", NODE_CLASS_OP_FILTER, 0);
+	node_type_socket_templates(&ntype, cmp_node_python_in, cmp_node_python_out);
+	node_type_init(&ntype, node_composit_init_python);
+	node_type_storage(&ntype, "NodePython", node_free_standard_storage, node_copy_standard_storage);
+
+	nodeRegisterType(&ntype);
+}

--- a/source/blender/nodes/composite/nodes/node_composite_recogni_object_id.c
+++ b/source/blender/nodes/composite/nodes/node_composite_recogni_object_id.c
@@ -25,13 +25,13 @@
 
 /* **************** RECOGNI OBJECT ID ******************** */
 static bNodeSocketTemplate cmp_node_recogni_oid_in[] = {
-    {SOCK_FLOAT, 1, N_("ObjectID"), 1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 1.0f, PROP_FACTOR},
-    {-1, 0, ""}
+    {SOCK_FLOAT, N_("ObjectID"), 1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 1.0f, PROP_FACTOR},
+    {-1, ""}
 };
 
 static bNodeSocketTemplate cmp_node_recogni_oid_out[] = {
-	{SOCK_RGBA, 0, N_("Image")}, 
-	{-1, 0, ""},
+	{SOCK_RGBA, N_("Image")}, 
+	{-1, ""},
 };
 
 void register_node_type_cmp_recogni_object_id(void)

--- a/source/blender/nodes/composite/nodes/node_composite_recogni_object_id.c
+++ b/source/blender/nodes/composite/nodes/node_composite_recogni_object_id.c
@@ -1,0 +1,47 @@
+/*
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ * The Original Code is Copyright (C) 2006 Blender Foundation.
+ * All rights reserved.
+ */
+
+/** \file
+ * \ingroup cmpnodes
+ */
+
+#include "node_composite_util.h"
+
+/* **************** RECOGNI OBJECT ID ******************** */
+static bNodeSocketTemplate cmp_node_recogni_oid_in[] = {
+    {SOCK_FLOAT, 1, N_("Object ID"), 1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 1.0f, PROP_FACTOR},
+    {-1, 0, ""}};
+
+static bNodeSocketTemplate cmp_node_recogni_oid_out[] = {{SOCK_RGBA, 0, N_("Color")}, {-1, 0, ""}};
+
+static void node_composit_init_recogni_object_id(bNodeTree *UNUSED(ntree), bNode *node)
+{
+  node->custom1 |= CMP_CHAN_RGB;
+}
+
+void register_node_type_cmp_recogni_object_id(void)
+{
+  static bNodeType ntype;
+
+  cmp_node_type_base(&ntype, CMP_NODE_RECOGNI_OBJECT_ID, "Recogni Object ID", NODE_CLASS_OP_COLOR, 0);
+  node_type_socket_templates(&ntype, cmp_node_recogni_oid_in, cmp_node_recogni_oid_out);
+  node_type_init(&ntype, node_composit_init_recogni_object_id);
+
+  nodeRegisterType(&ntype);
+}

--- a/source/blender/nodes/composite/nodes/node_composite_recogni_object_id.c
+++ b/source/blender/nodes/composite/nodes/node_composite_recogni_object_id.c
@@ -25,23 +25,21 @@
 
 /* **************** RECOGNI OBJECT ID ******************** */
 static bNodeSocketTemplate cmp_node_recogni_oid_in[] = {
-    {SOCK_FLOAT, 1, N_("Object ID"), 1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 1.0f, PROP_FACTOR},
-    {-1, 0, ""}};
+    {SOCK_FLOAT, 1, N_("ObjectID"), 1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 1.0f, PROP_FACTOR},
+    {-1, 0, ""}
+};
 
-static bNodeSocketTemplate cmp_node_recogni_oid_out[] = {{SOCK_RGBA, 0, N_("Color")}, {-1, 0, ""}};
-
-static void node_composit_init_recogni_object_id(bNodeTree *UNUSED(ntree), bNode *node)
-{
-  node->custom1 |= CMP_CHAN_RGB;
-}
+static bNodeSocketTemplate cmp_node_recogni_oid_out[] = {
+	{SOCK_RGBA, 0, N_("Image")}, 
+	{-1, 0, ""},
+};
 
 void register_node_type_cmp_recogni_object_id(void)
 {
   static bNodeType ntype;
 
-  cmp_node_type_base(&ntype, CMP_NODE_RECOGNI_OBJECT_ID, "Recogni Object ID", NODE_CLASS_OP_COLOR, 0);
+  cmp_node_type_base(&ntype, CMP_NODE_RECOGNI_OBJECT_ID, "RecogniOID", NODE_CLASS_OP_FILTER, 0);
   node_type_socket_templates(&ntype, cmp_node_recogni_oid_in, cmp_node_recogni_oid_out);
-  node_type_init(&ntype, node_composit_init_recogni_object_id);
 
   nodeRegisterType(&ntype);
 }

--- a/source/blender/python/intern/bpy_interface.c
+++ b/source/blender/python/intern/bpy_interface.c
@@ -325,6 +325,8 @@ static void pystatus_exit_on_error(PyStatus status)
 }
 #endif
 
+int initCompositorPython();
+
 /* call BPY_context_set first */
 void BPY_python_start(bContext *C, int argc, const char **argv)
 {
@@ -498,6 +500,8 @@ void BPY_python_start(bContext *C, int argc, const char **argv)
   BPy_init_modules(C);
 
   pyrna_alloc_types();
+
+  initCompositorPython();
 
 #ifndef WITH_PYTHON_MODULE
   /* py module runs atexit when bpy is freed */

--- a/source/blender/windowmanager/WM_api.h
+++ b/source/blender/windowmanager/WM_api.h
@@ -805,6 +805,10 @@ bool WM_jobs_has_running(struct wmWindowManager *wm);
 void WM_job_main_thread_lock_acquire(struct wmJob *job);
 void WM_job_main_thread_lock_release(struct wmJob *job);
 
+/* Recogni: Custom python node */
+typedef void(*MainThreadCallback)(void*);
+void WM_run_in_main_thread(MainThreadCallback, void*);
+
 /* clipboard */
 char *WM_clipboard_text_get(bool selection, int *r_len);
 char *WM_clipboard_text_get_firstline(bool selection, int *r_len);

--- a/source/blender/windowmanager/intern/wm_init_exit.c
+++ b/source/blender/windowmanager/intern/wm_init_exit.c
@@ -159,6 +159,8 @@ static void wm_free_reports(wmWindowManager *wm)
   BKE_reports_clear(&wm->reports);
 }
 
+void wm_window_create_main_queue();
+
 static bool wm_start_with_console = false;
 
 void WM_init_state_start_with_console_set(bool value)
@@ -224,6 +226,7 @@ static void sound_jack_sync_callback(Main *bmain, int mode, double time)
 /* only called once, for startup */
 void WM_init(bContext *C, int argc, const char **argv)
 {
+  wm_window_create_main_queue();
 
   if (!G.background) {
     wm_ghost_init(C); /* note: it assigns C to ghost! */

--- a/source/blender/windowmanager/intern/wm_window.c
+++ b/source/blender/windowmanager/intern/wm_window.c
@@ -40,6 +40,7 @@
 
 #include "BLI_blenlib.h"
 #include "BLI_math.h"
+#include "BLI_threads.h"
 #include "BLI_utildefines.h"
 
 #include "BLT_translation.h"
@@ -1547,9 +1548,50 @@ static int wm_window_timer(const bContext *C)
   return retval;
 }
 
+/* Recogni: Custom python node */
+ThreadQueue* wm_main_thread_queue = NULL;
+
+typedef struct MainThreadWork {
+  MainThreadCallback callback;
+  void *user_data;
+} MainThreadWork;
+
+void WM_run_in_main_thread(MainThreadCallback callback, void *user_data)
+{
+  MainThreadWork* work = malloc(sizeof(MainThreadWork));
+  work->callback = callback;
+  work->user_data = user_data;
+  BLI_thread_queue_push(wm_main_thread_queue, work);
+}
+
+void wm_window_create_main_queue()
+{
+  //Never freed
+  if (wm_main_thread_queue == NULL) {
+    wm_main_thread_queue = BLI_thread_queue_init();
+  }
+}
+
+int wm_window_process_main_queue_events()
+{
+  BLI_assert(BLI_thread_is_main());
+
+  int count = 0;
+
+  MainThreadWork *work = NULL;
+  while (work = BLI_thread_queue_pop_timeout(wm_main_thread_queue, 0)) {
+    (work->callback)(work->user_data);
+    free(work);
+    count++;
+  }
+  return count;
+}
+
 void wm_window_process_events(const bContext *C)
 {
   BLI_assert(BLI_thread_is_main());
+
+  wm_window_process_main_queue_events();
 
   int hasevent = GHOST_ProcessEvents(g_system, 0); /* 0 is no wait */
 


### PR DESCRIPTION
This PR moves the Blender version downloaded from the official release to 3.2.0. After this PR is merged, the the downstream https://github.com/recogni/blender-scripts will start being built against that version by virtue of the `latest` tag reference in its [`Dockerfile`](https://github.com/recogni/blender-scripts/blob/master/Dockerfile#L3).